### PR TITLE
Scenarios 5 and 6

### DIFF
--- a/R/scenarios_script.R
+++ b/R/scenarios_script.R
@@ -222,4 +222,4 @@ plot_func("prevalent_hospitalizations")
 
 
 ## UNCOMMENT to print matrix of summary output measures
-print(summary_out)
+#print(summary_out)

--- a/R/scenarios_script.R
+++ b/R/scenarios_script.R
@@ -30,9 +30,13 @@ source("setup_model.R")
 #   4 = Extend Scenario 3 stay-at-home order from 14 days to 42 days; 
 #       lifting of stay-at-home is followed by 21 days social distancing for all; 
 #       vulnerable populations continue to social distance until 30 days past peak
+#   5 = Extend Scenario 4 stay-at-home order from 42 days to 51 days (May 18th)
+#   6 = Extend Scenario 4 stay-at-home order from 51 days to 65 days
+#   99 = Stay-at-home for entire epidemic (added in response to public inquiry)
 
 # Scenarios to be run
-scn_vec <- c("1", "2", "3", "4")
+#scn_vec <- c("1", "2", "3", "4", "5", "6", "99")
+scn_vec <- c("1", "2", "3", "4", "5", "6")
 
 # Intializing lists to store the raw model output and processed model output
 lst_out_raw <- list()
@@ -82,6 +86,33 @@ for (i in 1:length(scn_vec)) {
     parms$start_time_sip <- 6
     parms$end_time_sip <- 6+42
     parms$start_time_60plus_distancing <- 1+5+42+21
+    parms$end_time_60plus_distancing <- -Inf
+    parms$sixty_plus_days_past_peak <- 30
+    
+  } else if (i_scenario == "5") {
+    parms$start_time_social_distancing <- 1
+    parms$end_time_social_distancing <- 1+5+51+21
+    parms$start_time_sip <- 6
+    parms$end_time_sip <- 6+51
+    parms$start_time_60plus_distancing <- 1+5+51+21
+    parms$end_time_60plus_distancing <- -Inf
+    parms$sixty_plus_days_past_peak <- 30
+
+  } else if (i_scenario == "6") {
+    parms$start_time_social_distancing <- 1
+    parms$end_time_social_distancing <- 1+5+65+21
+    parms$start_time_sip <- 6
+    parms$end_time_sip <- 6+65
+    parms$start_time_60plus_distancing <- 1+5+65+21
+    parms$end_time_60plus_distancing <- -Inf
+    parms$sixty_plus_days_past_peak <- 30
+        
+  } else if (i_scenario == "99") {
+    parms$start_time_social_distancing <- 1
+    parms$end_time_social_distancing <- 1+5+365
+    parms$start_time_sip <- 6
+    parms$end_time_sip <- 6+365
+    parms$start_time_60plus_distancing <- 1+5+365
     parms$end_time_60plus_distancing <- -Inf
     parms$sixty_plus_days_past_peak <- 30
     
@@ -191,4 +222,4 @@ plot_func("prevalent_hospitalizations")
 
 
 ## UNCOMMENT to print matrix of summary output measures
-# print(summary_out)
+print(summary_out)

--- a/R/scenarios_script.R
+++ b/R/scenarios_script.R
@@ -32,7 +32,7 @@ source("setup_model.R")
 #       vulnerable populations continue to social distance until 30 days past peak
 #   5 = Extend Scenario 4 stay-at-home order from 42 days to 51 days (May 18th)
 #   6 = Extend Scenario 4 stay-at-home order from 51 days to 65 days
-#   99 = Stay-at-home for entire epidemic (added in response to public inquiry)
+#   99 = Stay-at-home for entire epidemic (for comparison purposes)
 
 # Scenarios to be run
 #scn_vec <- c("1", "2", "3", "4", "5", "6", "99")


### PR DESCRIPTION
Hello,

This request adds Scenarios 5 and 6 to the model. Using the [May 13th presentation](https://mn.gov/covid19/assets/MNmodel_PPT%205.13.20_FINAL%20915AM_tcm1148-431824.pdf), I verified that this yields mortality results that match your published results, both for the entire epidemic and through May 31st. 

I also added a new scenario ("Scenario 99") that imposes stay-at-home throughout the entire epidemic, for use as a baseline comparison. If "Scenario 1" represents one unrealistic and unfeasible extreme, "Scenario 99" represents the other. This scenario is commented out by default, since it was not part of your presentation. 

Thanks for your work. I hope this is helpful, since I am sure you are quite busy. I am especially looking forward to seeing how your model handles testing and treatment, because I have no chance of reproducing any of that.

Thanks,
James Heaney
jamesjheaney.com